### PR TITLE
Jasonbreen tim chang87/mid 97 housekeeping after merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "main": ".webpack/main",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "concurrently \"webpack serve --hot\" \"tsc --watch\" \"electronmon --trace-warnings .\" ",
+    "start": "concurrently \"electron-forge start\" \"npx tailwindcss -i ./src/App.css -o ./src/output.css --watch\"",
     "electron": "electron .",
     "proxy": "nodemon proxy/proxy.js",
-    "start:forge": "concurrently \"electron-forge start\" \"npx tailwindcss -i ./src/App.css -o ./src/output.css --watch\"",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App () {
   // select a directory button to select a path
   const handleButtonClick = () => {
     window.electronAPI
-      .openFile()
+      .openFile('directory')
       .then((result: string) => {
         // Expect result to be a directory
         window.electronAPI
@@ -84,11 +84,11 @@ function App () {
 
   const copyConfig = () => {
     window.electronAPI
-      .openFile()
-      .then((result: string) => {
+      .openFile('file')
+      .then((fileSelected: string) => {
         // Expect result to be a directory
         window.electronAPI
-          .copyConfig(result)
+          .copyConfig(fileSelected)
       }).catch((err: unknown) => console.log('copyConfig Error: ', err))
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,16 @@ function App () {
   // })
   // }
 
+  const copyConfig = () => {
+    window.electronAPI
+      .openFile()
+      .then((result: string) => {
+        // Expect result to be a directory
+        window.electronAPI
+          .copyConfig(result)
+      }).catch((err: unknown) => console.log('copyConfig Error: ', err))
+  }
+
   return (
     <>
       <header>
@@ -93,6 +103,9 @@ function App () {
         <button className="btn btn-sm" onClick={handleButtonClick}>Select A Directory</button>
         <div className='reFetch'>
            <button className="btn btn-sm" onClick={fetchFromDB}>Fetch Tests</button>
+        </div>
+        <div className='copyConfig'>
+           <button className="btn btn-sm" onClick={copyConfig}>Select Config</button>
         </div>
       </div>
       <hr />

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -121,4 +121,5 @@ export type APIfuncs ={
   getAllRoutes: () => Promise<string>;
   // getRoute: (route: any) => any;
   getTest: (test: string) => Promise<string>;
+  copyConfig: (dir: string) => void;
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -116,7 +116,7 @@ export type ResultProps = {
 }
 
 export type APIfuncs ={
-  openFile: () => Promise<string>;
+  openFile: (fileOrDir: string) => Promise<string>;
   parseFiles: (dir: string) => Promise<fetchCall[]>;
   getAllRoutes: () => Promise<string>;
   // getRoute: (route: any) => any;

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+
+const configManager = {
+  copyConfig: (filePath) => {
+    // OpenFileDialog? <= This is handled by the electron FE
+    fs.copyFileSync(filePath, configManager.determineDir() + 'config.json')
+  },
+
+  determineDir: () => {
+    // Determine users OS to get the correct path for config file
+    // https://cameronnokes.com/blog/how-to-store-user-data-in-electron/
+    let fileDir: string
+
+    // Mac OS: ~/Library/Application Support/<Your App Name (taken from the name property in package.json)>
+    // Windows: C:\Users\<you>\AppData\Local\<Your App Name>
+    // Linux: ~/.config/<Your App Name>
+
+    if (process.platform === 'win32') {
+      fileDir = process.env.APPDATA + '\\Local\\middle-aware\\'
+    } else if (process.platform === 'darwin') {
+      fileDir = process.env.HOME + '/Library/Application Support/middle-aware/'
+    } else { // assume linux
+      fileDir = process.env.HOME + '.config/middle-aware/'
+    }
+
+    return fileDir
+  },
+
+  readConfig: () => {
+    // let config = {}
+
+    // fs.readFile(fileDir + 'config.json', { encoding: 'utf8' }, (err, data) => {
+    //   if (err) throw err
+    //   config = JSON.parse(data)
+    // })
+
+    return JSON.parse(fs.readFileSync(configManager.determineDir() + 'config.json', { encoding: 'utf8' }))
+  }
+
+}
+
+export default configManager

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -36,7 +36,18 @@ export const determineDir = () => {
 }
 
 export const readConfig = () => {
-  return JSON.parse(fs.readFileSync(determineDir() + 'config.json', { encoding: 'utf8' }))
+  if (fs.existsSync(determineDir() + 'config.json')) {
+    return JSON.parse(fs.readFileSync(determineDir() + 'config.json', { encoding: 'utf8' }))
+  } else { // Return default configuration if the config.json does not exist
+    return {
+      rootDir: '',
+      backEnd: '',
+      startScript: 'npm run start',
+      targetDir: determineDir() + '/shadowDir',
+      MONGODB_URI: '',
+      proxyPort: '9003'
+    }
+  }
 }
 
 export default { copyConfig, determineDir, readConfig }

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -1,42 +1,42 @@
 import fs from 'fs'
 
-const configManager = {
-  copyConfig: (filePath) => {
-    // OpenFileDialog? <= This is handled by the electron FE
-    fs.copyFileSync(filePath, configManager.determineDir() + 'config.json')
-  },
-
-  determineDir: () => {
-    // Determine users OS to get the correct path for config file
-    // https://cameronnokes.com/blog/how-to-store-user-data-in-electron/
-    let fileDir: string
-
-    // Mac OS: ~/Library/Application Support/<Your App Name (taken from the name property in package.json)>
-    // Windows: C:\Users\<you>\AppData\Local\<Your App Name>
-    // Linux: ~/.config/<Your App Name>
-
-    if (process.platform === 'win32') {
-      fileDir = process.env.APPDATA + '\\Local\\middle-aware\\'
-    } else if (process.platform === 'darwin') {
-      fileDir = process.env.HOME + '/Library/Application Support/middle-aware/'
-    } else { // assume linux
-      fileDir = process.env.HOME + '.config/middle-aware/'
-    }
-
-    return fileDir
-  },
-
-  readConfig: () => {
-    // let config = {}
-
-    // fs.readFile(fileDir + 'config.json', { encoding: 'utf8' }, (err, data) => {
-    //   if (err) throw err
-    //   config = JSON.parse(data)
-    // })
-
-    return JSON.parse(fs.readFileSync(configManager.determineDir() + 'config.json', { encoding: 'utf8' }))
-  }
-
+interface middleAwareConfig{
+    backend?: string,
+    proxyPort?: number
+}
+interface configManager{
+    copyConfig: (filePath: string) => void,
+    determineDir: ()=> void,
+    readConfig: () => middleAwareConfig
 }
 
-export default configManager
+export const copyConfig = (filePath) => {
+  // OpenFileDialog? <= This is handled by the electron FE
+  fs.copyFileSync(filePath, determineDir() + 'config.json')
+}
+
+export const determineDir = () => {
+  // Determine users OS to get the correct path for config file
+  // https://cameronnokes.com/blog/how-to-store-user-data-in-electron/
+  let fileDir: string
+
+  // Mac OS: ~/Library/Application Support/<Your App Name (taken from the name property in package.json)>
+  // Windows: C:\Users\<you>\AppData\Local\<Your App Name>
+  // Linux: ~/.config/<Your App Name>
+
+  if (process.platform === 'win32') {
+    fileDir = process.env.APPDATA + '\\Local\\middle-aware\\'
+  } else if (process.platform === 'darwin') {
+    fileDir = process.env.HOME + '/Library/Application Support/middle-aware/'
+  } else { // assume linux
+    fileDir = process.env.HOME + '.config/middle-aware/'
+  }
+
+  return fileDir
+}
+
+export const readConfig = () => {
+  return JSON.parse(fs.readFileSync(determineDir() + 'config.json', { encoding: 'utf8' }))
+}
+
+export default { copyConfig, determineDir, readConfig }

--- a/src/dbModels.ts
+++ b/src/dbModels.ts
@@ -1,13 +1,20 @@
 import mongoose, { Schema, model, Document, connect, Types, ConnectOptions, ObjectId } from 'mongoose'
-import * as dotenv from 'dotenv'
+// import * as dotenv from 'dotenv'
 import { TestRequest } from './Types'
-// process.env.MONGODB_URI as MONGODB_URI
+const path = require('path')
+// import process.env.MONGODB_URI as MONGODB_URI
+require('dotenv').config({ path: ``})
+
+// path.relative()
+// Absolute path to .env won't change
+// Move information to config file
+// Export object from .js file?
 
 // Load config
-dotenv.config({ path: '../.env' })
+// dotenv.config()
+console.log('process.env: ', process.env)
 
-// const MONGODB_URI: string = process.env.MONGODB_URI!
-const MONGODB_URI = 'mongodb+srv://justinwmarchant:l9HPcrjosl0h4tFr@middle-aware-cluster.8frnuhl.mongodb.net/Middle-Aware?retryWrites=true&w=majority'
+const MONGODB_URI: string = process.env.MONGODB_URI!
 
 // create extended ConnectOptions interface by adding two new property
 interface MongoConnectOps extends ConnectOptions {
@@ -22,6 +29,8 @@ const connectionOptions: MongoConnectOps = {
   // sets the name of the DB that our collections are part of
   // dbName: 'middle-aware'
 }
+console.log('process.env: ', process.env)
+console.log('MONGODB_URI', MONGODB_URI)
 
 mongoose.connect(MONGODB_URI, connectionOptions)
   .then(() => console.log('Connected to Mongo DB.'))

--- a/src/dbModels.ts
+++ b/src/dbModels.ts
@@ -2,9 +2,6 @@ import mongoose, { Schema, model, Document, connect, Types, ConnectOptions, Obje
 import { TestRequest } from './Types'
 import configManager from './configManager'
 
-// Call the configManager and get the MONGODB_URI property
-const MONGODB_URI: string = configManager.readConfig().MONGODB_URI
-
 // create extended ConnectOptions interface by adding two new property
 interface MongoConnectOps extends ConnectOptions {
   useNewUrlParser?: boolean
@@ -19,9 +16,18 @@ const connectionOptions: MongoConnectOps = {
   // dbName: 'middle-aware'
 }
 
-mongoose.connect(MONGODB_URI, connectionOptions)
-  .then(() => console.log('Connected to Mongo DB.'))
-  .catch(err => console.log(err))
+function mongoConnect () {
+  // Call the configManager and get the MONGODB_URI property
+  const MONGODB_URI: string = configManager.readConfig().MONGODB_URI
+
+  if (MONGODB_URI !== '') {
+    mongoose.connect(MONGODB_URI, connectionOptions)
+      .then(() => console.log('Connected to Mongo DB.'))
+      .catch(err => console.log(err))
+  }
+}
+
+mongoConnect()
 
 type StringObject = {
     [key: string]: string;
@@ -110,4 +116,4 @@ const TestSchema: Schema<TestSchemaType> = new Schema({
 const Route = model('Route', RouteSchema)
 const Test = model('Test', TestSchema)
 
-export { Route, Test }
+export { Route, Test, mongoConnect }

--- a/src/dbModels.ts
+++ b/src/dbModels.ts
@@ -1,20 +1,9 @@
 import mongoose, { Schema, model, Document, connect, Types, ConnectOptions, ObjectId } from 'mongoose'
-// import * as dotenv from 'dotenv'
 import { TestRequest } from './Types'
-const path = require('path')
-// import process.env.MONGODB_URI as MONGODB_URI
-require('dotenv').config({ path: ``})
+import configManager from './configManager'
 
-// path.relative()
-// Absolute path to .env won't change
-// Move information to config file
-// Export object from .js file?
-
-// Load config
-// dotenv.config()
-console.log('process.env: ', process.env)
-
-const MONGODB_URI: string = process.env.MONGODB_URI!
+// Call the configManager and get the MONGODB_URI property
+const MONGODB_URI: string = configManager.readConfig().MONGODB_URI
 
 // create extended ConnectOptions interface by adding two new property
 interface MongoConnectOps extends ConnectOptions {
@@ -29,8 +18,6 @@ const connectionOptions: MongoConnectOps = {
   // sets the name of the DB that our collections are part of
   // dbName: 'middle-aware'
 }
-console.log('process.env: ', process.env)
-console.log('MONGODB_URI', MONGODB_URI)
 
 mongoose.connect(MONGODB_URI, connectionOptions)
   .then(() => console.log('Connected to Mongo DB.'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import configManager from './configManager'
+import { mongoConnect } from './dbModels'
 require('source-map-support').install()
 // const parseAPIRequests = require('./parseAPIRequests');
 const session = require('electron').session
@@ -90,7 +91,10 @@ async function handleGetRoute (event, route) { return await db.default.getRoute(
 
 async function handleGetTest (event, test) { return await db.default.getTest(test) }
 
-function handleCopyConfig (event, dir) { configManager.copyConfig(dir) }
+function handleCopyConfig (event, dir) {
+  configManager.copyConfig(dir)
+  mongoConnect()
+}
 
 app.whenReady().then(() => {
   ipcMain.handle('dialog:openFile', handleFileOpen)

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,8 +74,9 @@ app.on('activate', () => {
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and import them here.
 
-async function handleFileOpen () {
-  const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow)
+async function handleFileOpen (event, fileOrDir) {
+  console.log('fileOrDir: ', fileOrDir)
+  const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, { properties: [(fileOrDir === 'directory' ? 'openDirectory' : 'openFile')] })
   if (canceled) {
     //
   } else {
@@ -83,21 +84,13 @@ async function handleFileOpen () {
   }
 }
 
-function handleFileParse (event, dir) {
-  return parseAPIRequests(dir)
-}
+function handleFileParse (event, dir) { return parseAPIRequests(dir) }
 
-async function handleGetRoute (event, route) {
-  return await db.default.getRoute(route)
-}
+async function handleGetRoute (event, route) { return await db.default.getRoute(route) }
 
-async function handleGetTest (event, test) {
-  return await db.default.getTest(test)
-}
+async function handleGetTest (event, test) { return await db.default.getTest(test) }
 
-function handleCopyConfig (event, dir) {
-  configManager.copyConfig(dir)
-}
+function handleCopyConfig (event, dir) { configManager.copyConfig(dir) }
 
 app.whenReady().then(() => {
   ipcMain.handle('dialog:openFile', handleFileOpen)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import configManager from './configManager'
 require('source-map-support').install()
 // const parseAPIRequests = require('./parseAPIRequests');
 const session = require('electron').session
@@ -42,10 +43,10 @@ const createWindow = (): void => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
-  session.defaultSession.setProxy({
-    proxyRules: 'http://127.0.0.1:9000'
-    // proxyBypassRules: 'localhost'
-  })
+  // session.defaultSession.setProxy({
+  //   proxyRules: 'http://127.0.0.1:9000'
+  //   // proxyBypassRules: 'localhost'
+  // })
 
   console.log('MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY:', MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY)
 
@@ -74,9 +75,7 @@ app.on('activate', () => {
 // code. You can also put them in separate files and import them here.
 
 async function handleFileOpen () {
-  const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
-    properties: ['openDirectory']
-  })
+  const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow)
   if (canceled) {
     //
   } else {
@@ -88,18 +87,23 @@ function handleFileParse (event, dir) {
   return parseAPIRequests(dir)
 }
 
-async function handleGetRoute(event, route) {
+async function handleGetRoute (event, route) {
   return await db.default.getRoute(route)
 }
 
-async function handleGetTest(event, test) {
+async function handleGetTest (event, test) {
   return await db.default.getTest(test)
 }
 
+function handleCopyConfig (event, dir) {
+  configManager.copyConfig(dir)
+}
+
 app.whenReady().then(() => {
-  ipcMain.handle('dialog:openFile', handleFileOpen);
-  ipcMain.handle('parseFiles', handleFileParse);
+  ipcMain.handle('dialog:openFile', handleFileOpen)
+  ipcMain.handle('parseFiles', handleFileParse)
   ipcMain.handle('db:getAllRoutes', db.default.getAllRoutes)
-  ipcMain.handle('db:getRoute', handleGetRoute);
-  ipcMain.handle('db:getTest', handleGetTest);
-});
+  ipcMain.handle('db:getRoute', handleGetRoute)
+  ipcMain.handle('db:getTest', handleGetTest)
+  ipcMain.handle('copyConfig', handleCopyConfig)
+})

--- a/src/parseAPI-FE-Req.ts
+++ b/src/parseAPI-FE-Req.ts
@@ -69,7 +69,7 @@ function parseAPIRequests (dirToParse: string, outArray: fetchCall[] = []) {
             }
 
             outArray.push({
-              method: (options.method ? options.method : 'GET'),
+              method: (options?.method ? options.method : 'GET'),
               route: funcCall.arguments[0]?.value ?? source.slice(funcCall.arguments[0].start + 1, funcCall.arguments[0].end - 1),
               options: (options || null)
             })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,7 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  openFile: () => ipcRenderer.invoke('dialog:openFile'),
+  openFile: (fileOrDir) => ipcRenderer.invoke('dialog:openFile', fileOrDir),
   parseFiles: (dir) => ipcRenderer.invoke('parseFiles', dir),
   getAllRoutes: () => ipcRenderer.invoke('db:getAllRoutes'),
   getRoute: (route) => ipcRenderer.invoke('db:getRoute', route),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,5 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   parseFiles: (dir) => ipcRenderer.invoke('parseFiles', dir),
   getAllRoutes: () => ipcRenderer.invoke('db:getAllRoutes'),
   getRoute: (route) => ipcRenderer.invoke('db:getRoute', route),
-  getTest: (test) => ipcRenderer.invoke('db:getTest', test)
+  getTest: (test) => ipcRenderer.invoke('db:getTest', test),
+  copyConfig: (dir) => ipcRenderer.invoke('copyConfig', dir)
 })

--- a/src/proxyServer.ts
+++ b/src/proxyServer.ts
@@ -4,12 +4,13 @@
 //  3. dbController so we can integrate with the DB
 import { IncomingHttpHeaders } from 'http'
 import { createProxyMiddleware, Filter, Options, RequestHandler } from 'http-proxy-middleware'
-//import * as express from 'express'
-const express = require('express')
 import { Application, Request, Response, NextFunction } from 'express'
 import dbController from './dbController'
 import { Details, Payload, TestType, RouteType } from './Types'
 import { performance } from 'perf_hooks'
+import { readConfig } from './configManager'
+// import * as express from 'express'
+const express = require('express')
 
 // setup express server so that we can start the proxy server and disable etag
 // etag needs to be disabled otherwise we will get 304 status code for frequent requests and the reponse body will not be captured
@@ -124,6 +125,8 @@ const setHeader = async (req, res, next) => {
 
 // Proxy Server Route to handle all other requests (requests from user's frontend)
 app.use('**', setHeader, proxy)
-app.listen(9000, () => {
-  console.log('Proxy server listening on port 9000')
+
+const { proxyPort } = readConfig()
+app.listen(proxyPort, () => {
+  console.log(`Proxy server listening on port ${proxyPort}`)
 })


### PR DESCRIPTION
`package.json`
 - Updated start script to incorporate electron-forge changes. Removed start:forge.

`src/App.tsx`
 - Refactored to pass string 'directory' or 'file' to openFile handler. (see `src/Types.ts`)
 - Added `copyConfig()` function and associated button to enable user selection of config file

`src/Types.ts`
 - Updated `openFile:` to reflect new string parameter
   - This allows the handler to be used for selection of either a directory or individual file
 - Added copyConfig method for configuration management

`src/configManager.ts`
 - Created new module to allow user specified config file to be saved and accessed by the application
 - `determineDir` uses environment variables to determine the appropriate application data folder
 - `copyConfig` copies the user specified config file to the app data folder
 - `readConfig` reads the config stored in the application data folder and returns the configuration object

`src/dbModels.ts`
 - Refactored to utilize the configuration manager module for MongoDB_URI

`src/index.ts` & `src/preload.ts`
 - Commented out the proxy on port 9000 to prevent conflict with middle-aware agent
 - Added handler for configManager functions

`src/parseAPI-FE-Req.ts`
 - Cleanup - added '?' to object access for scenarios where options are not provided

`src/proxyServer.ts`
 - Imported `readConfig` to utilize user configuration to set the proxy port for middle-aware

